### PR TITLE
Fix typo (appreviation -> abbreviation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ npm install @stefanzweifel/js-swiss-cantons
 
 ### Usage
 
-Currently there two methods available on the CantonManager Class: `getByAppreviation` and `getByName`.
+Currently there two methods available on the CantonManager Class: `getByAbbreviation` and `getByName`.
 
 ```javascript
 import CantonManager from '@stefanzweifel/js-swiss-cantons';
 
 let manager = new CantonManager;
-let canton = manager.getByAppreviation('SH');
+let canton = manager.getByAbbreviation('SH');
 let canton = manager.getByName('Schaffhausen');
 
 console.log(

--- a/src/CantonManager.js
+++ b/src/CantonManager.js
@@ -7,9 +7,9 @@ export default class {
      * @param  {string} abbreviation
      * @return {Canton}
      */
-    getByAppreviation(abbreviation) {
+    getByAbbreviation(abbreviation) {
         let search = new CantonSearch;
-        return search.findByAppreviation(abbreviation);
+        return search.findByAbbreviation(abbreviation);
     }
 
     /**
@@ -31,7 +31,7 @@ export default class {
         let search = new CantonSearch;
 
         try {
-            return search.findByAppreviation(value);
+            return search.findByAbbreviation(value);
         }
         catch (e) {
             console.warn(e.message);

--- a/src/Searcher/CantonSearch.js
+++ b/src/Searcher/CantonSearch.js
@@ -8,7 +8,7 @@ export default class {
      * @param  {string} abbreviation
      * @return {Canton}
      */
-    findByAppreviation(abbreviation) {
+    findByAbbreviation(abbreviation) {
         let result = cantons.filter((value) => {
             return value.abbreviation === abbreviation.toUpperCase();
         });

--- a/test/CantonManagerTest.js
+++ b/test/CantonManagerTest.js
@@ -3,7 +3,7 @@ import CantonManager from '../src/CantonManager.js';
 
 test('it_returns_canton_by_abbreviation', t => {
    let manager = new CantonManager;
-   let result = manager.getByAppreviation('NW');
+   let result = manager.getByAbbreviation('NW');
 
    t.is(result.getAbbreviation(), 'NW');
    t.is(result.setLanguage('de').getName(), 'Nidwalden');

--- a/test/Searcher/CantonSearchTest.js
+++ b/test/Searcher/CantonSearchTest.js
@@ -3,7 +3,7 @@ import CantonSearch from '../../src/Searcher/CantonSearch.js';
 
 test('it_finds_canton_by_abbreviation', t => {
     let search = new CantonSearch;
-    let canton = search.findByAppreviation('SH');
+    let canton = search.findByAbbreviation('SH');
 
     t.is(canton.getAbbreviation(), 'SH');
 });
@@ -12,7 +12,7 @@ test('it_throws_error_if_no_canton_can_be_found_for_abbreviation', t => {
     let search = new CantonSearch;
 
     const error = t.throws(() => {
-        search.findByAppreviation('FOO-BAR');
+        search.findByAbbreviation('FOO-BAR');
     }, Error);
 
     t.is(error.message, 'No canton found for abbreviation FOO-BAR');
@@ -20,7 +20,7 @@ test('it_throws_error_if_no_canton_can_be_found_for_abbreviation', t => {
 
 test('it_set_abbreviation_to_uppercase', t => {
     let search = new CantonSearch;
-    let canton = search.findByAppreviation('gl');
+    let canton = search.findByAbbreviation('gl');
 
     t.is(canton.getAbbreviation(), 'GL');
 });


### PR DESCRIPTION
I've changed the word appreviation to the correct English word abbreviation (like in the php-swiss-cantons plugin). I updated the tests (they're still green) too.

